### PR TITLE
chore: Refactor environment path handling and remove debug logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,35 @@
-// {
-//   "version": "0.2.0",
-//   "configurations": [
-//     {
-//       "name": "Next.js: debug server-side",
-//       "port": 9230,
-//       "request": "attach",
-//       "skipFiles": ["<node_internals>/**"],
-//       "type": "node",
-//       "sourceMapPathOverrides": {
-//         "/turbopack/[project]/*": "${webRoot}/*"
-//       }
-//     },
-//     {
-//       "type": "chrome",
-//       "request": "launch",
-//       "name": "Next.js: debug client-side",
-//       "url": "http://localhost:3000",
-//       "webRoot": "${workspaceFolder}",
-//       "sourceMapPathOverrides": {
-//         "/turbopack/[project]/*": "${webRoot}/*"
-//       }
-//     }
-//   ],
-//   "compounds": [
-//     {
-//       "name": "Next.js: debug full stack",
-//       "configurations": [
-//         "Next.js: debug client-side",
-//         "Next.js: debug server-side"
-//       ],
-//       "stopAll": true
-//     }
-//   ]
-// }
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "port": 9230,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      "sourceMapPathOverrides": {
+        "/turbopack/[project]/*": "${webRoot}/*"
+      }
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Next.js: debug client-side",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "/turbopack/[project]/*": "${webRoot}/*"
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Next.js: debug full stack",
+      "configurations": [
+        "Next.js: debug client-side",
+        "Next.js: debug server-side"
+      ],
+      "stopAll": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "from-a2b",
-  "version": "0.62.30",
+  "version": "0.62.31",
   "private": true,
   "scripts": {
     "clean": "next lint --fix && tsc --noEmit && prettier --write . && next build",

--- a/src/lib/blobStorage/getEnvPath.ts
+++ b/src/lib/blobStorage/getEnvPath.ts
@@ -1,0 +1,15 @@
+import { env } from "@lib/env/server";
+
+export const getEnvPath = () => {
+  const envMap: Record<string, string> = {
+    development: "Local",
+    preview: "Preview",
+    production: "Production",
+  };
+
+  return (
+    envMap[env.NODE_ENV as keyof typeof envMap] ||
+    envMap[env.VERCEL_ENV as keyof typeof envMap] ||
+    "noenv"
+  );
+};

--- a/src/lib/blobStorage/uploadFile.ts
+++ b/src/lib/blobStorage/uploadFile.ts
@@ -2,6 +2,7 @@ import { fileToBlob } from "@utils/file";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { backendClient } from "./edgestore-server";
+import { getEnvPath } from "./getEnvPath";
 
 const UploadProfileSchema = z.object({
   file: z.instanceof(File),
@@ -23,6 +24,7 @@ export const uploadProfilePicture = async ({
     },
     ctx: {
       userId: userId,
+      envPath: getEnvPath(),
     },
     options: {
       manualFileName: `${userId}-${nanoid()}`,

--- a/src/lib/server-url.ts
+++ b/src/lib/server-url.ts
@@ -5,7 +5,6 @@ import { env } from "./env/server";
  * This method return the server URL based on the environment.
  */
 export const getServerUrl = () => {
-  console.log("🚀 ~ getServerUrl ~ env.VERCEL_URL:", env.VERCEL_URL);
   if (typeof window !== "undefined") {
     return window.location.origin;
   }


### PR DESCRIPTION
- Add getEnvPath utility for consistent environment path generation
- Update EdgeStore server configuration to use dynamic environment paths
- Remove unnecessary console log in server URL generation
- Uncomment VSCode debug configuration
- Bump package version to 0.62.31